### PR TITLE
Increase the minimum CPU specs so the workflow can run on AWS

### DIFF
--- a/data_preprocessing.yaml
+++ b/data_preprocessing.yaml
@@ -1,5 +1,5 @@
 resources:
-  cpus: 1
+  cpus: 1+
 
 envs:
   DATA_BUCKET_NAME: sky-demo-data-test

--- a/eval.yaml
+++ b/eval.yaml
@@ -1,5 +1,5 @@
 resources:
-  cpus: 1
+  cpus: 1+
   # Add GPUs here
 
 envs:

--- a/train.yaml
+++ b/train.yaml
@@ -1,5 +1,5 @@
 resources:
-  cpus: 1
+  cpus: 1+
   # Add GPUs here
 
 envs:


### PR DESCRIPTION
This changes the CPU spec to `cpu: 1+` so that the workflow can run on AWS.